### PR TITLE
Support db2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ const config = { ... } // needs options
 
 // Install the plugin
 Server
-  .use(require('scuttlebot/plugins/master')) // required
-  .use(require('ssb-backlinks')) // required
+  .use(require('ssb-backlinks')) // required if not using ssb-db2
   .use(require('ssb-social-index')({
     namespace: 'edits',
     type: 'update',

--- a/index.js
+++ b/index.js
@@ -228,6 +228,7 @@ module.exports = function (options) {
 
     function about(value) {
       return ssb.db.operators.equal(seekAbout, value, {
+        prefix: 32,
         indexType: 'value_content_about',
       })
     }

--- a/index.js
+++ b/index.js
@@ -217,17 +217,13 @@ module.exports = function (options) {
       )
     }
 
-    const bValue = Buffer.from('value')
-    const bContent = Buffer.from('content')
-    const bAbout = Buffer.from('about')
-
     function seekAbout(buffer) {
       let p = 0 // note you pass in p!
-      p = seekKey(buffer, p, bValue)
+      p = seekKey(buffer, p, Buffer.from('value'))
       if (p < 0) return
-      p = seekKey(buffer, p, bContent)
+      p = seekKey(buffer, p, Buffer.from('content'))
       if (p < 0) return
-      return seekKey(buffer, p, bAbout)
+      return seekKey(buffer, p, Buffer.from('about'))
     }
 
     function about(value) {
@@ -247,7 +243,7 @@ module.exports = function (options) {
             and(type(options.type), about(dest)),
             reverse ? descending() : null,
             limit ? paginate(limit) : null,
-            liveOp ? live(liveOpts) : null,
+            live ? liveOp(liveOpts) : null,
             toPullStream(),
           )
         )

--- a/index.js
+++ b/index.js
@@ -229,6 +229,8 @@ module.exports = function (options) {
     function about(value) {
       return ssb.db.operators.equal(seekAbout, value, {
         prefix: 32,
+        prefixOffset: 1,
+        useMap: true,
         indexType: 'value_content_about',
       })
     }

--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ module.exports = function (options) {
 
     function read ({ reverse = false, limit, live, old, dest }) {
       if (ssb.db) {
-        const { and, type, live: liveOp, toPullStream } = ssb.db.operators
+        const { and, type, descending, paginate, live: liveOp, toPullStream } = ssb.db.operators
 
         const liveOpts = live && old ? { old: true }: {}
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/ssbc/ssb-social-index.git"
   },
   "dependencies": {
-    "flumeview-reduce": "^1.3.9",
+    "bipf": "^1.4.0",
     "pull-defer": "^0.2.3",
     "pull-stream": "^3.6.9",
     "ssb-ref": "^2.7.1"


### PR DESCRIPTION
This PR should allow this module to use db2 queries instead of backlinks queries if db2 has been loaded as a secret stack plugin.

Totally untested so this might not work at all ;-) 

@KyleMaas you should be able to use this module to get names, images etc. instead of using getProfile. Note the API is a bit different because multiple people can assign about messages for something where ssb-browser before would just take the authors own values. Also this module is used by ssb-about.

This might need some caching to be really performant, but first step is just getting it working :)

Also this needs a README update, but first things first.