### PR TITLE
Add option "getSocialValue" to specify alternative algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ server.about.socialValue({ key: 'name', dest: '@3r4+IyB5NVl2in6QOZHIu9oSrZud+NuV
 })
 ```
 
-The algorithm for the socialValue is based of the following priorities:
+The default algorithm for the socialValue is based of the following priorities:
 1. the most recent value I have set for that `dest`/ `key` (if it exists)
 2. the most recent value that the 'owner' `dest` set for that key (if they've self assigned it)
 3. the most recent + 'popular' value for the `dest` / `key` (from all data in your network)
+
+You can however provide your own custom algorithm using the option `getSocialValue`. (See code for details)
 
 ### `server.about.latestValue({ key, dest }, cb)`
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function (options) {
   if (!options.destField || options.destField === '') {
     throw new Error('ssb-social-index must be called with a nonempty "destField" string option')
   }
+  const getSocialValue = options.getSocialValue || defaultGetSocialValue
 
   const exports = {}
 
@@ -288,7 +289,7 @@ module.exports = function (options) {
     }
   }
 
-  function getSocialValue (socialValues, yourId, authorId) {
+  function defaultGetSocialValue (socialValues, yourId, authorId) {
     if (socialValues[yourId]) {
       // you assigned a value, use this!
       return socialValues[yourId]


### PR DESCRIPTION
I have a use case that is 99.9% covered by ssb-social-index, but I need to tweak the algorithm implemented in getSocialValue(). This very simple PR would allow this. What do you think?

In case you are curious about that use case: I have alternative networks, where shs.caps is a feed id. (I called it an 'owned network'). I want that feed to provide network-wide default values for social values.